### PR TITLE
Using new hotkey system and remove redundant events

### DIFF
--- a/DiscordWebhook/README.md
+++ b/DiscordWebhook/README.md
@@ -4,7 +4,7 @@ This plugin submits data in Monster Hunter: World to specified Discord channel.
 
 ## Installation
 
-1. Download the zipped plugin [here](https://cdn.discordapp.com/attachments/402557384209203200/756267026745655343/DiscordWebhook.zip);
+1. Download the zipped plugin [here](https://cdn.discordapp.com/attachments/652762250746265600/756763311470542948/DiscordWebhook.zip);
 2. Extract it's contents to `HunterPie/Modules`;
 3. Edit the `HunterPie/Modules/DiscordWebhook/config.json` and set your webhook link. Read [Setting up Webhook](#Setting-up-Webhook) if you need help.
 4. Run HunterPie.

--- a/DiscordWebhook/main.cs
+++ b/DiscordWebhook/main.cs
@@ -4,6 +4,7 @@ using System.IO;
 using HunterPie;
 using HunterPie.Core;
 using HunterPie.Core.Events;
+using HunterPie.Core.Input;
 using Debugger = HunterPie.Logger.Debugger;
 using Newtonsoft.Json;
 using System.Net;
@@ -19,12 +20,11 @@ namespace HunterPie.Plugins
 {
     public class DiscordIntegration : IPlugin
     {
+        List<int> hotkeyIds = new List<int>();
+
         public string Name { get; set; }
         public string Description { get; set; }
         public Game Context { get; set; }
-
-        IntPtr hWnd;
-        HwndSource source;
 
         // Cache build link so we don't have to get a new one every single time someone uses a command
         private string _buildLink { get; set; }
@@ -46,7 +46,6 @@ namespace HunterPie.Plugins
 
         public void Initialize(Game context)
         {
-
             Name = "DiscordWebhook";
             Description = "A HunterPie plugin posts MHW data to Discord.";
 
@@ -64,101 +63,50 @@ namespace HunterPie.Plugins
 
         private void SetHotkey()
         {
-            // We need the current window handle to register a global hotkey
-            // HunterPie is multithreaded, so we should invoke to get the main window handle
-            Application.Current.Dispatcher.Invoke(new Action(() =>
-            {
-                hWnd = new WindowInteropHelper(Application.Current.MainWindow).EnsureHandle();
-                source = HwndSource.FromHwnd(hWnd);
+            Dictionary<string, Action> dummy = new Dictionary<string, Action>();
+            dummy["Shift+Ctrl+P"] = myHotkeyDPS;
+            dummy["Shift+Ctrl+G"] = myHotkeyGear;
 
-                // This is our "callback"
-                source.AddHook(HwndHook);
-
-                // Key modifiers
-                // 0x1 = Alt; 0x2 = Ctrl; 0x4 = Shift
-                int Modifiers = 0x2 | 0x4;
-
-                // Setting the key to P, you can find the keys here: https://github.com/Haato3o/HunterPie/blob/master/HunterPie/Core/KeyboardHook.cs
-                KeyboardHookHelper.KeyboardKeys keyP = KeyboardHookHelper.KeyboardKeys.P;
-                KeyboardHookHelper.KeyboardKeys keyG = KeyboardHookHelper.KeyboardKeys.G;
-
-                // Now we register the hotkey
-                bool success = KeyboardHookHelper.RegisterHotKey(hWnd, 999, Modifiers, (int)keyP);
-                success = success & KeyboardHookHelper.RegisterHotKey(hWnd, 998, Modifiers, (int)keyG);
-
-                if (success)
-                {
-                    Debugger.Log("Registered hotkey!");
-                } else
-                {
-                    Debugger.Error("Failed to register hotkey");
+            // Now we register them iterating the dummy dictionary
+            foreach (string hk in dummy.Keys) {
+                int hkId = Hotkey.Register(hk, dummy[hk]);
+                if (hkId > 0) {
+                    hotkeyIds.Add(hkId);
                 }
-            }));
+            }
+            dummy.Clear();
         }
 
         private void UnsetHotkey()
         {
-            // Make sure to unregister the hotkey on Unload
-            Application.Current.Dispatcher.Invoke(new Action(() =>
-            {
-                bool success = KeyboardHookHelper.UnregisterHotKey(hWnd, 999);
-                success = success & KeyboardHookHelper.UnregisterHotKey(hWnd, 998);
-
-                // Make sure to remove the hook, so the next time you register a hotkey it won't
-                // call the callback function multiple times
-                source.RemoveHook(HwndHook);
-                
-                if (success)
-                {
-                    Debugger.Log("Successfully unregistered hotkey");
-                } else
-                {
-                    Debugger.Error("failed to unregister");
-                }
-            }));
+            foreach (int hkId in hotkeyIds) {
+                Hotkey.Unregister(hkId);
+            }
+            hotkeyIds.Clear();
         }
 
-        private IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        private void myHotkeyDPS()
         {
-            const int WM_HOTKEY = 0x0312;
-            string DiscordMsg = null;
-            switch (msg)
-            {
-                case WM_HOTKEY:
-                    switch (wParam.ToInt32())
-                    {
-                        // Check if it's our hotkey id
-                        case 999: 
-                            if (DPSString != null)
-                                DiscordMsg = $"```{DPSString}```";
-                            break;
-                        case 998: 
-                            DiscordMsg = BuildLink;
-                            break;
-                    }
-                    break;
-            }
+            if (DPSString == null)
+                return;
 
-            if (DiscordMsg != null)
-                PostToDiscord(DiscordMsg);
+            PostToDiscord($"```{DPSString}```");
+        }
 
-            return IntPtr.Zero;
+        private void myHotkeyGear()
+        {
+            UpdateBuildLink();
+            PostToDiscord(TinyURL);
         }
 
         private void HookEvents()
         {
-            Context.Player.OnCharacterLogin += UpdateBuildLink;
-            Context.Player.OnSessionChange += UpdateBuildLink;
-            Context.Player.OnWeaponChange += UpdateBuildLink;
             Context.Player.OnPeaceZoneEnter += StopCalculateDPS;
             Context.Player.OnPeaceZoneLeave += StartCalculateDPS;
         }
 
         private void UnhookEvents()
         {
-            Context.Player.OnCharacterLogin -= UpdateBuildLink;
-            Context.Player.OnSessionChange -= UpdateBuildLink;
-            Context.Player.OnWeaponChange -= UpdateBuildLink;
             Context.Player.OnPeaceZoneEnter -= StopCalculateDPS;
             Context.Player.OnPeaceZoneLeave -= StartCalculateDPS;
             Context.FirstMonster.OnHPUpdate -= UpdateDPSString;
@@ -178,10 +126,10 @@ namespace HunterPie.Plugins
             WebHook = config.Webhook;
        }
 
-       private void UpdateBuildLink(object source, EventArgs args)
-       {
-           BuildLink = Honey.LinkStructureBuilder(Context.Player.GetPlayerGear());
-       }
+        private void UpdateBuildLink()
+        {
+            BuildLink = Honey.LinkStructureBuilder(Context.Player.GetPlayerGear());
+        }
 
        private void StartCalculateDPS(object source, EventArgs args)
        {

--- a/DiscordWebhook/main.cs
+++ b/DiscordWebhook/main.cs
@@ -101,14 +101,13 @@ namespace HunterPie.Plugins
 
         private void HookEvents()
         {
-            Context.Player.OnPeaceZoneEnter += StopCalculateDPS;
-            Context.Player.OnPeaceZoneLeave += StartCalculateDPS;
+            Context.FirstMonster.OnHPUpdate += UpdateDPSString;
+            Context.SecondMonster.OnHPUpdate += UpdateDPSString;
+            Context.ThirdMonster.OnHPUpdate += UpdateDPSString;
         }
 
         private void UnhookEvents()
         {
-            Context.Player.OnPeaceZoneEnter -= StopCalculateDPS;
-            Context.Player.OnPeaceZoneLeave -= StartCalculateDPS;
             Context.FirstMonster.OnHPUpdate -= UpdateDPSString;
             Context.SecondMonster.OnHPUpdate -= UpdateDPSString;
             Context.ThirdMonster.OnHPUpdate -= UpdateDPSString;
@@ -131,19 +130,6 @@ namespace HunterPie.Plugins
             BuildLink = Honey.LinkStructureBuilder(Context.Player.GetPlayerGear());
         }
 
-       private void StartCalculateDPS(object source, EventArgs args)
-       {
-            Context.FirstMonster.OnHPUpdate += UpdateDPSString;
-            Context.SecondMonster.OnHPUpdate += UpdateDPSString;
-            Context.ThirdMonster.OnHPUpdate += UpdateDPSString;
-        }
-
-       private void StopCalculateDPS(object source, EventArgs args)
-       {
-           Context.FirstMonster.OnHPUpdate -= UpdateDPSString;
-           Context.SecondMonster.OnHPUpdate -= UpdateDPSString;
-           Context.ThirdMonster.OnHPUpdate -= UpdateDPSString;
-       }
 
        private void UpdateDPSString(object source, MonsterUpdateEventArgs args)
        {

--- a/DiscordWebhook/module.json
+++ b/DiscordWebhook/module.json
@@ -3,7 +3,7 @@
   "Description": "A HunterPie plugin posts MHW data to Discord.",
   "EntryPoint":  "main.cs",
   "Author": "AceLan",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Dependencies": [
     "Libs\\netstandard.dll",
     "Libs\\Microsoft.Extensions.Logging.Abstractions.dll"


### PR DESCRIPTION
1. Switch to use new hotkey system
2. {Start,Stop}CalculateDPS do not work well as expected, so remove them all and register hook event directly when loaded
3. Fix ident
4. Call UpdateBuildLink() when hotkey is pressed, instead of updating by event hooks